### PR TITLE
Support definitions pattern for when $ref's are't pre-resolved

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,8 @@ function resolveOptions(options) {
 	options.cloneSchema = options.cloneSchema == false ? false : true;
 	options.supportPatternProperties = options.supportPatternProperties || false;
 	options.keepNotSupported = options.keepNotSupported || [];
-	options.strictMode = options.strictMode == false ? false : true;
+  options.strictMode = options.strictMode == false ? false : true;
+  options.definitionKeywords = options.definitionKeywords || [];
 
 	if (typeof options.patternPropertiesHandler !== 'function') {
 		options.patternPropertiesHandler = patternPropertiesHandler;

--- a/lib/converters/schema.js
+++ b/lib/converters/schema.js
@@ -15,10 +15,11 @@ function convertFromSchema (schema, options) {
 function convertSchema (schema, options) {
 	var structs = options._structs;
 	var notSupported = options._notSupported;
-	var strictMode = options.strictMode;
+  var strictMode = options.strictMode;
+  var definitionKeywords = options.definitionKeywords;
 	var i = 0;
 	var j = 0;
-	var struct = null;
+  var struct = null;
 
 	for (i; i < structs.length; i++) {
 		struct = structs[i]
@@ -38,7 +39,15 @@ function convertSchema (schema, options) {
 		} else if (typeof schema[struct] === 'object') {
 			schema[struct] = convertSchema(schema[struct], options)
 		}
-	}
+  }
+
+  for (i = 0; i < definitionKeywords.length; i++) {
+    struct = definitionKeywords[i]
+
+    if (typeof schema[struct] === 'object') {
+      schema[struct] = convertProperties(schema[struct], options)
+    }
+  }
 
 	if ('properties' in schema) {
 		schema.properties = convertProperties(schema.properties, options)

--- a/test/definition_keywords.test.js
+++ b/test/definition_keywords.test.js
@@ -1,0 +1,40 @@
+var test = require('tape');
+var convert = require('..');
+
+test('handles conversion in keywords specified in additionalKeywords', function (assert) {
+  assert.plan(1)
+
+  var schema = {
+    definitions: {
+      sharedDefinition: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: 'string',
+            nullable: true
+          }
+        }
+      }
+    }
+  }
+
+  var result = convert(schema, {
+    definitionKeywords: ['definitions']
+  })
+
+  var expected = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    definitions: {
+      sharedDefinition: {
+        type: 'object',
+        properties: {
+          foo: {
+            type: ['string', 'null']
+          }
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(result, expected)
+})


### PR DESCRIPTION
Sometimes it isn't ideal to have to resolve refs before running
openapi-schema-to-json-schema. In my case I need to run type generators
on individual schema files, not the combined schemas I'd get from
running something like json-ref-resolver.

This adds a new option called definitionKeywords that takes an array of
keywords to treat as "definition objects". Each property in the
"definition object" will be treated as a subschema and have all
conversions run on them.

I'd expect most people to use `definitionKeywords: ['definitions']`, but I think leaving that up to the user makes sense since the spec doesn't specify a standard.