### PR TITLE
perf: do not deep clone upfront

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var deepEqual = require('fast-deep-equal');
 var convert = require('./lib/convert');
-var clone = require('lodash.clonedeep');
 
 module.exports = openapiSchemaToJsonSchema;
 module.exports.fromSchema = openapiSchemaToJsonSchema;
@@ -9,20 +8,12 @@ module.exports.fromParameter = openapiParameterToJsonSchema;
 function openapiSchemaToJsonSchema(schema, options) {
 	options = resolveOptions(options);
 
-	if (options.cloneSchema) {
-		schema = clone(schema);
-	}
-
 	var jsonSchema = convert.fromSchema(schema, options);
 	return jsonSchema;
 }
 
 function openapiParameterToJsonSchema(parameter, options) {
 	options = resolveOptions(options);
-
-	if (options.cloneSchema) {
-		parameter = clone(parameter);
-	}
 
 	var jsonSchema = convert.fromParameter(parameter, options);
 	return jsonSchema;

--- a/lib/converters/schema.js
+++ b/lib/converters/schema.js
@@ -13,7 +13,11 @@ function convertFromSchema (schema, options) {
 }
 
 function convertSchema (schema, options) {
-	var structs = options._structs;
+  if (options.cloneSchema) {
+    schema = Object.assign({}, schema);
+  }
+
+  var structs = options._structs;
 	var notSupported = options._notSupported;
 	var strictMode = options.strictMode;
 	var i = 0;
@@ -24,8 +28,15 @@ function convertSchema (schema, options) {
 		struct = structs[i]
 
 		if (Array.isArray(schema[struct])) {
-			for (j; j < schema[struct].length; j++) {
+      var cloned = false;
+
+      for (j; j < schema[struct].length; j++) {
 				if (!isObject(schema[struct][j])) {
+          if (options.cloneSchema && !cloned) {
+            cloned = true;
+            schema[struct] = schema[struct].slice();
+          }
+
 					schema[struct].splice(j, 1)
 					j--
 					continue
@@ -92,17 +103,14 @@ function convertProperties (properties, options) {
 	}
 
 	for (key in properties) {
-		removeProp = false
 		property = properties[key]
 
 		if (!isObject(property)) {
 			continue
 		}
 
-		options._removeProps.forEach(function (prop) {
-			if (property[prop] === true) {
-				removeProp = true
-			}
+    removeProp = options._removeProps.some(function (prop) {
+			return property[prop] === true
 		})
 
 		if (removeProp) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2579,11 +2579,6 @@
       "integrity": "sha1-+CbJtOKoUR2E46yinbBeGk87cqk=",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.escaperegexp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "author": "OpenAPI Contrib",
   "license": "MIT",
   "dependencies": {
-    "fast-deep-equal": "^3.1.3",
-    "lodash.clonedeep": "^4.5.0"
+    "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/test/clone_schema.test.js
+++ b/test/clone_schema.test.js
@@ -3,6 +3,7 @@ var convert = require('../');
 
 test('cloning schema by default', function (assert) {
   var schema;
+  var cloned;
   var result;
   var expected;
 
@@ -10,18 +11,41 @@ test('cloning schema by default', function (assert) {
 
   schema = {
     type: 'string',
-    nullable: true
+    nullable: true,
+    properties: {
+      foo: true,
+      bar: {
+        allOf: [
+          null,
+          {
+            type: 'string',
+          },
+          null
+        ]
+      }
+    }
   }
 
-  result = convert(schema)
+  cloned = JSON.parse(JSON.stringify(schema));
+
+  result = convert(cloned)
 
   expected = {
     $schema: 'http://json-schema.org/draft-04/schema#',
-    type: ['string', 'null']
+    type: ['string', 'null'],
+    properties: {
+      bar: {
+        allOf: [
+          {
+            type: 'string',
+          }
+        ]
+      }
+    }
   }
 
   assert.deepEqual(result, expected, 'converted')
-  assert.notEqual(result, schema, 'schema cloned')
+  assert.deepEqual(cloned, schema, 'schema cloned')
 })
 
 test('cloning schema with cloneSchema option', function (assert) {
@@ -32,6 +56,8 @@ test('cloning schema with cloneSchema option', function (assert) {
     nullable: true
   }
 
+  var cloned = JSON.parse(JSON.stringify(schema))
+
   var result = convert(schema, { cloneSchema: true })
 
   var expected = {
@@ -40,7 +66,7 @@ test('cloning schema with cloneSchema option', function (assert) {
   }
 
   assert.deepEqual(result, expected, 'converted')
-  assert.notEqual(result, schema, 'schema cloned')
+  assert.deepEqual(cloned, schema, 'schema cloned')
 })
 
 test('handles circular references', function (assert) {


### PR DESCRIPTION
cloneDeep is fairly expensive in certain cases and does not need to be implement in the way it is now, since we visit each object, and hence can simply shallow copy it before modyfing.
Using shallow copy of each object before visiting it significantly (by around 25-35%) improves the perfomance of `@stoplight/http-spec#transformOas3Operations`. Tested against various specs, such as Stripe, Whatsapp, etc.
Obviously, the results will vary - if a given document does not have schemas or has a handful of small schemas, the difference is likely to be less notable.
