### PR TITLE
Add an option to convert examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ If the handler is not provided, the default handler is used. If `additionalPrope
 
 See `test/pattern_properties.test.js` for examples how this works.
 
+#### `convertExamples` (boolean)
+
+If set to `true`, `example` and `examples` from OpenAPI schemas will convert to `examples` defined in JSON Schema Draft 7. This is not enabled by default because `examples` keyword isn't defined in JSON Schema Draft 4. (See [JSON Schema "examples" keyword](https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5) and Swagger's documentation on ["Adding examples"](https://swagger.io/docs/specification/adding-examples/) for more information).
+
 ## Converting OpenAPI parameters
 
 OpenAPI parameters can be converted:

--- a/lib/converters/schema.js
+++ b/lib/converters/schema.js
@@ -77,6 +77,10 @@ function convertSchema (schema, options) {
 		schema = convertPatternProperties(schema, options.patternPropertiesHandler)
 	}
 
+	if (options.convertExamples) {
+		schema = convertExamples(schema)
+	}
+
 	for (i = 0; i < notSupported.length; i++) {
 		delete schema[notSupported[i]]
 	}
@@ -237,6 +241,37 @@ function convertPatternProperties (schema, handler) {
 	delete schema['x-patternProperties']
 
 	return handler(schema)
+}
+
+function convertExamples (schema) {
+	var examples = [];
+
+	if (Array.isArray(schema.examples)) {
+		examples = schema.examples;
+	} else if (isObject(schema.examples)) {
+		var keys = Object.keys(schema.examples);
+
+		for (let i = 0; i < keys.length; i++) {
+			var example = schema.examples[keys[i]];
+			if (
+				isObject(example)
+				&& Object.prototype.hasOwnProperty.call(example, 'value')
+			) {
+				examples.push(example.value);
+			}
+		}
+	}
+
+	if (typeof schema.example !== 'undefined') {
+		examples.push(schema.example);
+		delete schema.example
+	}
+
+	if (examples.length !== 0) {
+		schema.examples = examples;
+	}
+
+	return schema
 }
 
 function cleanRequired (required, properties) {

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -1,0 +1,63 @@
+var test = require('tape');
+var convert = require('../');
+
+test('using examples array', function (assert) {
+  assert.plan(1)
+
+  var schema = {
+    type: 'string',
+    examples: ['foo', 'bar']
+  }
+
+  var result = convert.fromSchema(schema, { convertExamples: true })
+
+  var expected = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    type: 'string',
+    examples: ['foo', 'bar']
+  }
+
+  assert.deepEqual(result, expected, 'examples converted')
+})
+
+test('using examples object', function (assert) {
+  assert.plan(1)
+
+  var schema = {
+    type: 'string',
+    examples: {
+      foo: {value: 'bar'},
+      fizz: {value: 'buzz'},
+      invalid: [],
+    }
+  }
+
+  var result = convert.fromSchema(schema, { convertExamples: true })
+
+  var expected = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    type: 'string',
+    examples: ['bar', 'buzz']
+  }
+
+  assert.deepEqual(result, expected, 'examples converted')
+})
+
+test('using example field', function (assert) {
+  assert.plan(1)
+
+  var schema = {
+    type: 'string',
+    example: 'foo'
+  }
+
+  var result = convert.fromSchema(schema, { convertExamples: true })
+
+  var expected = {
+    $schema: 'http://json-schema.org/draft-04/schema#',
+    type: 'string',
+    examples: ['foo']
+  }
+
+  assert.deepEqual(result, expected, 'example converted')
+})


### PR DESCRIPTION
According to the OpenAPI spec, there are two ways of providing examples for a schema⁽¹⁾:

- using `examples` field with a mapping of [Example Object](https://swagger.io/specification/#example-object)s.
- using `example` field which is a single example without further description or summary.

As examples aren't supported in JSON Schema Draft 4, this library currently drops the `example` field by default and leaves the `examples` field untouched (which may produce invalid schemas I guess). Since JSON Schema Draft 7 however, it is possible to use the "examples" keyword ⁽²⁾:

> 9.5. "examples"
> The value of this keyword MUST be an array. There are no restrictions placed on the values within the array. When multiple occurrences of this keyword are applicable to a single sub-instance, implementations MUST provide a flat array of all values rather than an array of arrays.
>
> This keyword can be used to provide sample JSON values associated with a particular schema, for the purpose of illustrating usage. It is RECOMMENDED that these values be valid against the associated schema.
> 
> Implementations MAY use the value(s) of "default", if present, as an additional example. If "examples" is absent, "default" MAY still be used in this manner. 


This PR adds an option to convert OpenAPI's `example` and `examples` fields to JSON Schema Draft 7 examples.

---

⁽¹⁾ https://swagger.io/docs/specification/adding-examples/
⁽²⁾ https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.9.5